### PR TITLE
Fix for broken example(ncdDetect)

### DIFF
--- a/R/ncdDetect.R
+++ b/R/ncdDetect.R
@@ -21,7 +21,7 @@ ncdDetect <- function(predictions, scores, observations = NA, thres = NA) {
   # Make initial checks on input --------------------------------------------
 
   observation_available <- F
-  if (sum(as.numeric(is.na(sample_specific_predictions))) == 0) {
+  if ( ! any(is.na(observations)) ) {
     observation_available <- T
   }
   


### PR DESCRIPTION
This fix allows example(ncdDetect) to run without complaining about the sample_specific_predictions object not being found.